### PR TITLE
Scope packages for GitHub Packages publishing

### DIFF
--- a/packages/parallax/package.json
+++ b/packages/parallax/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "parallax",
+  "name": "@paralax-plugin/parallax",
   "version": "0.1.0",
   "description": "Face-driven parallax utilities for Paralax experiments",
   "type": "module",
@@ -13,6 +13,10 @@
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",
   "files": ["dist"],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.build.json"
   },

--- a/packages/tracking/package.json
+++ b/packages/tracking/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tracking",
+  "name": "@paralax-plugin/tracking",
   "version": "0.1.0",
   "description": "Face tracking utilities for Paralax projects",
   "type": "module",
@@ -13,6 +13,10 @@
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",
   "files": ["dist"],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.build.json"
   },


### PR DESCRIPTION
## Summary
- scope the parallax and tracking packages under the `@paralax-plugin` namespace
- configure publish settings to target the GitHub Packages registry with public access

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da6ff116e48331b433fefb8db98673