### PR TITLE
fix: align package scope with github org

### DIFF
--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -14,7 +14,7 @@ Both ship ESM + type definitions compiled with TypeScript. Follow the steps belo
 1. **Node & pnpm** – Use the versions defined in `.nvmrc`/`packageManager` (`Node 20+, pnpm 10+`).
 2. **Auth token** – Create a GitHub personal access token (classic) with the `write:packages` scope and add it to your local config:
    ```bash
-   npm config set @paralax-plugin:registry https://npm.pkg.github.com
+   npm config set @paralax-labs:registry https://npm.pkg.github.com
    npm config set //npm.pkg.github.com/:_authToken <TOKEN>
    ```
 3. **Clean workspace** – Ensure `git status` is clean and all tests pass.

--- a/packages/parallax/package.json
+++ b/packages/parallax/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@paralax-plugin/parallax",
+  "name": "@paralax-labs/parallax",
   "version": "0.1.0",
   "description": "Face-driven parallax utilities for Paralax experiments",
   "type": "module",

--- a/packages/tracking/package.json
+++ b/packages/tracking/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@paralax-plugin/tracking",
+  "name": "@paralax-labs/tracking",
   "version": "0.1.0",
   "description": "Face tracking utilities for Paralax projects",
   "type": "module",


### PR DESCRIPTION
## Summary
- update package scope to `@paralax-labs` so GitHub Packages recognizes the owner
- refresh publishing docs with the corrected scope configuration

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dcfbb3f8748331b52e22c92a784869